### PR TITLE
Per-reader friendly names in the web dashboard

### DIFF
--- a/open_obi_energy_meter/include/reader.h
+++ b/open_obi_energy_meter/include/reader.h
@@ -32,6 +32,7 @@ struct Reader {
   // config
   uint16_t setInterval = 0;      // last upload-interval requested (shown in UI)
   uint8_t  intervalTx  = 0;      // remaining cmd-14 retransmits to send
+  char     name[25] = {0};       // user-set friendly name ("" = unset); persisted in NVS ns "obiname"
   bool     mqttDiscovered = false;  // HA discovery config already published (reset on each MQTT connect)
 };
 
@@ -46,6 +47,7 @@ bool gw_delete_reader(const uint8_t handle[3]);                       // drop a 
 uint32_t gw_uptime_s();
 // reader pairing gating (opt-in): a reader is only bound/keyed once assigned to this gateway
 bool gw_assign_reader(const uint8_t handle[3], bool on);              // accept (or drop) a reader onto this gateway
+void gw_set_reader_name(const uint8_t handle[3], const char *name);   // set ("" clears) the friendly name
 void gw_pair_all(uint16_t seconds);                                   // open a window that auto-assigns every reader
 uint32_t gw_pair_remaining_s();                                       // seconds left in the auto-pair window (0 = off)
 

--- a/open_obi_energy_meter/include/reader.h
+++ b/open_obi_energy_meter/include/reader.h
@@ -47,7 +47,7 @@ bool gw_delete_reader(const uint8_t handle[3]);                       // drop a 
 uint32_t gw_uptime_s();
 // reader pairing gating (opt-in): a reader is only bound/keyed once assigned to this gateway
 bool gw_assign_reader(const uint8_t handle[3], bool on);              // accept (or drop) a reader onto this gateway
-void gw_set_reader_name(const uint8_t handle[3], const char *name);   // set ("" clears) the friendly name
+bool gw_set_reader_name(const uint8_t handle[3], const char *name);   // set ("" clears) the friendly name; false = unknown reader
 void gw_pair_all(uint16_t seconds);                                   // open a window that auto-assigns every reader
 uint32_t gw_pair_remaining_s();                                       // seconds left in the auto-pair window (0 = off)
 

--- a/open_obi_energy_meter/src/gateway_web.cpp
+++ b/open_obi_energy_meter/src/gateway_web.cpp
@@ -276,6 +276,8 @@ h1{font-size:16px;margin:0;font-weight:650}.sub{color:var(--dim);font-size:12px}
 .meta{color:var(--dim);font-size:12px;font-family:var(--mono)}
 .del{margin-left:auto;background:transparent;border:1px solid var(--line);color:var(--dim);border-radius:7px;padding:3px 9px;cursor:pointer;font-size:13px;line-height:1}
 .del:hover{border-color:var(--red);color:var(--red)}
+.ren{background:transparent;border:1px solid var(--line);color:var(--dim);border-radius:7px;padding:3px 8px;cursor:pointer;font-size:12px;line-height:1}
+.ren:hover{border-color:var(--accent);color:var(--accent)}
 .uuid{font-family:var(--mono);font-size:11.5px;color:var(--dim);word-break:break-all;margin:7px 0 13px;
  padding:6px 9px;background:#0d131b;border-radius:8px;border:1px solid #1a222d}
 .uuid b{color:#9fb0c4;letter-spacing:.5px}
@@ -379,6 +381,7 @@ const T={
   vnote:'Die Firmware-Version MUSS im Dateinamen stehen, z.B. reader_v55.bin.',
   novers:'Keine Version im Dateinamen gefunden.\nBitte die richtige Firmware-Version in den Dateinamen schreiben, z.B. reader_v55.bin',
   vmiss:'Version fehlt im Dateinamen',
+  ren:'Name ändern',renq:'Name für Reader %i (leer = Standard):',
   samever:'Der Reader läuft bereits auf v%v — er akzeptiert dieselbe Version nicht (kein Reflash).\n\nTrotzdem versuchen?'},
  en:{sub:'869.5 MHz · SF7 · reading your meters directly',wifi:'WiFi',mqtt:'MQTT',radio:'Radio',readers:'Readers',
   offline:'offline',fw:'Firmware',batt:'Battery',opt:'Sensor',active:'active',nosig:'no signal',
@@ -400,6 +403,7 @@ const T={
   vnote:'The firmware version MUST be in the filename, e.g. reader_v55.bin.',
   novers:'No version found in the filename.\nPut the correct firmware version in the filename, e.g. reader_v55.bin',
   vmiss:'version missing in filename',
+  ren:'Rename',renq:'Name for reader %i (empty = default):',
   samever:'The reader is already on v%v — it will not accept the same version (no reflash).\n\nTry anyway?'}};
 let lang=localStorage.getItem('lang')||'de',L=T[lang];
 function setLang(x){lang=x;L=T[x];localStorage.setItem('lang',x);applyLang();tick();}
@@ -433,7 +437,7 @@ function bcol(p){return p>50?'var(--accent)':p>20?'var(--amber)':'var(--red)'}
 function fmt(s){const d=Math.floor(s/86400),h=Math.floor(s%86400/3600),m=Math.floor(s%3600/60);return (d?d+'d ':'')+(h?h+'h ':'')+m+'m'}
 let cfgLoaded=false;
 async function tick(){try{
- const st=await (await fetch('/api/status')).json(), rs=await (await fetch('/api/readers')).json();
+ const st=await (await fetch('/api/status')).json(), rs=await (await fetch('/api/readers')).json();_rs=rs;
  $('#logout_btn').style.display=(st.auth&&st.auth.enabled)?'':'none';   // only show logout when a login is required
  $('#sub').textContent='OBI Gateway '+(st.gw||st.gwid).toUpperCase();
  $('#gw').textContent=st.gwid_ascii+' · '+(st.mac||st.gwid);
@@ -458,11 +462,13 @@ async function tick(){try{
 function card(r){
  const p=Math.max(0,Math.min(100,Math.round((r.battery_mV-2400)/8)));
  const sens=r.infrared?`<span class="dot on"></span>${L.active}`:`<span class="dot idle"></span>${L.nosig}`;
+ const nm=r.name?esc(r.name):'';
  return `<div class="card${r.assigned?'':' pending'}">
-  <div class="hd"><span class="id">${r.id.toUpperCase()}</span>
+  <div class="hd"><span class="id">${nm||r.id.toUpperCase()}</span>
+   <button class="ren" onclick="renameRd('${r.id}')" title="${L.ren}">✎</button>
    <span class="tag ${r.type}">${r.type}</span>
    ${r.assigned?'':`<span class="tag pend">${L.pending}</span>`}
-   <span class="meta">FW ${r.softver} · HW ${r.hardver}${r.legacy?' · legacy':''} · ${r.rssi} dBm · ${r.snr} dB${r.paired?' · 🔒':''}</span>
+   <span class="meta">${nm?r.id.toUpperCase()+' · ':''}FW ${r.softver} · HW ${r.hardver}${r.legacy?' · legacy':''} · ${r.rssi} dBm · ${r.snr} dB${r.paired?' · 🔒':''}</span>
    <button class="del" onclick="delReader('${r.id}')" title="${L.del}">✕</button></div>
   <div class="uuid">${r.uuid?('<b>UUID</b> '+r.uuid):L.uuidwait}</div>
   ${r.bootloader?`<div class="boot">⚙ ${L.boot}</div>`:''}
@@ -485,6 +491,12 @@ function card(r){
   ${r.assigned&&!r.has_data&&!r.bootloader?`<div class="hint">⚠ ${L.irhint}</div>`:''}
  </div>`;
 }
+const esc=s=>String(s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+let _rs=[];
+async function renameRd(id){const r=_rs.find(x=>x.id===id)||{};
+ let v=prompt(L.renq.replace('%i',id.toUpperCase()),r.name||'');if(v===null)return;
+ v=v.trim().slice(0,24);
+ await fetch('/api/name?id='+id+'&name='+encodeURIComponent(v),{method:'POST'});tick();}
 async function setIv(id){const v=$('#iv_'+id).value;if(!v)return;await fetch('/api/interval?id='+id+'&seconds='+v,{method:'POST'});tick();}
 async function assignRd(id,on){await fetch('/api/assign?id='+id+'&on='+on,{method:'POST'});tick();}
 async function pairAll(){await fetch('/api/pairall',{method:'POST'});tick();}

--- a/open_obi_energy_meter/src/gateway_web.cpp
+++ b/open_obi_energy_meter/src/gateway_web.cpp
@@ -2169,8 +2169,11 @@ static void publishDiscovery(const Reader &r) {
   String stt = String(g_mqttTopic) + "/" + id;         // state topic (the JSON)
   String cmd = stt + "/set_interval";                  // command topic (number -> interval)
   String avt = avtTopic();                             // per-gateway LWT: online/offline
-  String dev = "\"dev\":{\"ids\":[\"" + uid + "\"],\"name\":\"OBI " + typeName(r.devType) + " " + id +
-               "\",\"mf\":\"OBI\",\"mdl\":\"" + typeName(r.devType) +
+  // device name: the user-set friendly name when present (Tasmota-style), else the technical default.
+  // Safe to change later: entity ids/history hang off uniq_id + state topic, both stay untouched.
+  String dev = "\"dev\":{\"ids\":[\"" + uid + "\"],\"name\":" +
+               (r.name[0] ? jstr(r.name) : "\"OBI " + String(typeName(r.devType)) + " " + id + "\"") +
+               ",\"mf\":\"OBI\",\"mdl\":\"" + String(typeName(r.devType)) +
                "\",\"sw\":\"" + String(r.softver) + "\",\"hw\":\"" + String(r.hardver) + "\"}";
 
   // --- sensors (dc/unit/sc == nullptr -> that field is omitted from the config) ---

--- a/open_obi_energy_meter/src/gateway_web.cpp
+++ b/open_obi_energy_meter/src/gateway_web.cpp
@@ -278,6 +278,7 @@ h1{font-size:16px;margin:0;font-weight:650}.sub{color:var(--dim);font-size:12px}
 .del:hover{border-color:var(--red);color:var(--red)}
 .ren{background:transparent;border:1px solid var(--line);color:var(--dim);border-radius:7px;padding:3px 8px;cursor:pointer;font-size:12px;line-height:1}
 .ren:hover{border-color:var(--accent);color:var(--accent)}
+.nmi{width:210px;max-width:55vw;font-size:16px;font-weight:600;padding:6px 9px}
 .uuid{font-family:var(--mono);font-size:11.5px;color:var(--dim);word-break:break-all;margin:7px 0 13px;
  padding:6px 9px;background:#0d131b;border-radius:8px;border:1px solid #1a222d}
 .uuid b{color:#9fb0c4;letter-spacing:.5px}
@@ -381,7 +382,7 @@ const T={
   vnote:'Die Firmware-Version MUSS im Dateinamen stehen, z.B. reader_v55.bin.',
   novers:'Keine Version im Dateinamen gefunden.\nBitte die richtige Firmware-Version in den Dateinamen schreiben, z.B. reader_v55.bin',
   vmiss:'Version fehlt im Dateinamen',
-  ren:'Name ändern',renq:'Name für Reader %i (leer = Standard):',
+  ren:'Name ändern',abort:'Abbrechen',
   samever:'Der Reader läuft bereits auf v%v — er akzeptiert dieselbe Version nicht (kein Reflash).\n\nTrotzdem versuchen?'},
  en:{sub:'869.5 MHz · SF7 · reading your meters directly',wifi:'WiFi',mqtt:'MQTT',radio:'Radio',readers:'Readers',
   offline:'offline',fw:'Firmware',batt:'Battery',opt:'Sensor',active:'active',nosig:'no signal',
@@ -403,7 +404,7 @@ const T={
   vnote:'The firmware version MUST be in the filename, e.g. reader_v55.bin.',
   novers:'No version found in the filename.\nPut the correct firmware version in the filename, e.g. reader_v55.bin',
   vmiss:'version missing in filename',
-  ren:'Rename',renq:'Name for reader %i (empty = default):',
+  ren:'Rename',abort:'Cancel',
   samever:'The reader is already on v%v — it will not accept the same version (no reflash).\n\nTry anyway?'}};
 let lang=localStorage.getItem('lang')||'de',L=T[lang];
 function setLang(x){lang=x;L=T[x];localStorage.setItem('lang',x);applyLang();tick();}
@@ -454,8 +455,9 @@ async function tick(){try{
  ].concat(st.temp_c!=null?[['Temp',`<b>${st.temp_c} °C</b>`]]:[])
   .map(p=>`<div class="pill"><span class="k">${p[0]}</span>${p[1]}</div>`).join('');
  $('#pair_st').textContent=st.pair_remaining_s>0?L.pairon.replace('%s',st.pair_remaining_s):L.pairoff;
- // don't blow away a reader card while its interval/file input is focused (you'd never finish typing)
- const ae=document.activeElement, editing=ae&&/^(iv_|fw_)/.test(ae.id||'');
+ // don't blow away a reader card while its interval/file input is focused (you'd never finish typing);
+ // renId keeps the inline rename field alive even if it loses focus (e.g. after tapping elsewhere on mobile)
+ const ae=document.activeElement, editing=renId!==null||(ae&&/^(iv_|fw_)/.test(ae.id||''));
  if(!editing && !uploading) $('#list').innerHTML=rs.length?rs.map(card).join(''):`<div class="card"><div class="hd"><span class="id">—</span></div><div class="uuid" style="border:0;background:0">${L.waiting}</div></div>`;
  if(st.ota&&st.ota.active){const el=$('#op_'+st.ota.target);if(el){const p=st.ota.size?Math.min(100,Math.max(0,Math.round(st.ota.served/st.ota.size*100))):0;el.textContent=L.otarun+' '+p+'%';}}
 }catch(e){}}
@@ -464,8 +466,12 @@ function card(r){
  const sens=r.infrared?`<span class="dot on"></span>${L.active}`:`<span class="dot idle"></span>${L.nosig}`;
  const nm=r.name?esc(r.name):'';
  return `<div class="card${r.assigned?'':' pending'}">
-  <div class="hd"><span class="id">${nm||r.id.toUpperCase()}</span>
-   <button class="ren" onclick="renameRd('${r.id}')" title="${L.ren}">✎</button>
+  <div class="hd">${renId===r.id
+   ?`<input class="nmi" id="nm_${r.id}" maxlength="24" value="${esc(r.name||'')}" placeholder="${r.id.toUpperCase()}" onkeydown="nmKey(event,'${r.id}')">
+   <button class="ren" onclick="nmSave('${r.id}')" title="${L.save}">✓</button>
+   <button class="ren" onclick="nmCancel()" title="${L.abort}">✕</button>`
+   :`<span class="id">${nm||r.id.toUpperCase()}</span>
+   <button class="ren" onclick="renameRd('${r.id}')" title="${L.ren}">✎</button>`}
    <span class="tag ${r.type}">${r.type}</span>
    ${r.assigned?'':`<span class="tag pend">${L.pending}</span>`}
    <span class="meta">${nm?r.id.toUpperCase()+' · ':''}FW ${r.softver} · HW ${r.hardver}${r.legacy?' · legacy':''} · ${r.rssi} dBm · ${r.snr} dB${r.paired?' · 🔒':''}</span>
@@ -492,11 +498,13 @@ function card(r){
  </div>`;
 }
 const esc=s=>String(s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
-let _rs=[];
-async function renameRd(id){const r=_rs.find(x=>x.id===id)||{};
- let v=prompt(L.renq.replace('%i',id.toUpperCase()),r.name||'');if(v===null)return;
- v=v.trim().slice(0,24);
+let _rs=[],renId=null;                       // renId = reader currently in inline-rename mode (tick pauses redraws)
+function redraw(){$('#list').innerHTML=_rs.map(card).join('');}
+function renameRd(id){renId=id;redraw();const el=$('#nm_'+id);if(el){el.focus();el.select();}}
+function nmCancel(){renId=null;redraw();}
+async function nmSave(id){const v=$('#nm_'+id).value.trim().slice(0,24);renId=null;
  await fetch('/api/name?id='+id+'&name='+encodeURIComponent(v),{method:'POST'});tick();}
+function nmKey(e,id){if(e.key==='Enter')nmSave(id);else if(e.key==='Escape')nmCancel();}
 async function setIv(id){const v=$('#iv_'+id).value;if(!v)return;await fetch('/api/interval?id='+id+'&seconds='+v,{method:'POST'});tick();}
 async function assignRd(id,on){await fetch('/api/assign?id='+id+'&on='+on,{method:'POST'});tick();}
 async function pairAll(){await fetch('/api/pairall',{method:'POST'});tick();}

--- a/open_obi_energy_meter/src/gateway_web.cpp
+++ b/open_obi_energy_meter/src/gateway_web.cpp
@@ -163,6 +163,7 @@ static String readersJson() {
     first = false;
     uint32_t age = (millis() - r.lastSeenMs) / 1000;
     j += "{\"id\":\"" + hex(r.handle, 3) + "\"";
+    j += ",\"name\":" + jstr(r.name);
     j += ",\"uuid\":" + (r.haveUuid ? "\"" + uuidStr(r.uuid) + "\"" : "null");
     j += ",\"type\":\"" + String(typeName(r.devType)) + "\"";
     j += ",\"paired\":" + String(r.haveKey ? "true" : "false");
@@ -655,6 +656,16 @@ static void handleInterval() {
     gw_request_interval(h, (uint16_t)secs);
     server.send(200, "application/json", "{\"ok\":true}");
   } else server.send(400, "application/json", "{\"ok\":false}");
+}
+
+// Set (or clear, empty name) a reader's friendly display name. WebServer already url-decodes arg().
+static void handleName() {
+  String id = server.arg("id");
+  if (id.length() != 6) { server.send(400, "application/json", "{\"ok\":false}"); return; }
+  uint8_t h[3];
+  for (int i = 0; i < 3; i++) h[i] = (uint8_t)strtol(id.substring(i * 2, i * 2 + 2).c_str(), nullptr, 16);
+  gw_set_reader_name(h, server.arg("name").c_str());
+  server.send(200, "application/json", "{\"ok\":true}");
 }
 
 static void handleMqttCfg() {
@@ -2000,6 +2011,7 @@ static void startServices() {
   server.on("/api/reboot",      HTTP_POST, guard(handleReboot));   // restart the gateway from the dashboard
   server.on("/api/factory_reset", HTTP_POST, guard(handleFactoryReset));  // wipe all settings + reboot to setup portal
   server.on("/api/assign",      HTTP_POST, guard(handleAssign));   // accept/drop a reader onto this gateway
+  server.on("/api/name",        HTTP_POST, guard(handleName));    // set/clear a reader's friendly name
   server.on("/api/pairall",     HTTP_POST, guard(handlePairAll));  // open the 3-min auto-accept window
   server.on("/radio",           HTTP_GET,  guard(handleRadioPage));  // live radio message view
   server.on("/api/radio",       HTTP_GET,  guard(handleRadioApi));

--- a/open_obi_energy_meter/src/gateway_web.cpp
+++ b/open_obi_energy_meter/src/gateway_web.cpp
@@ -676,8 +676,9 @@ static void handleName() {
   if (id.length() != 6) { server.send(400, "application/json", "{\"ok\":false}"); return; }
   uint8_t h[3];
   for (int i = 0; i < 3; i++) h[i] = (uint8_t)strtol(id.substring(i * 2, i * 2 + 2).c_str(), nullptr, 16);
-  gw_set_reader_name(h, server.arg("name").c_str());
-  server.send(200, "application/json", "{\"ok\":true}");
+  if (gw_set_reader_name(h, server.arg("name").c_str()))
+    server.send(200, "application/json", "{\"ok\":true}");
+  else server.send(400, "application/json", "{\"ok\":false}");
 }
 
 static void handleMqttCfg() {

--- a/open_obi_energy_meter/src/gateway_web.cpp
+++ b/open_obi_energy_meter/src/gateway_web.cpp
@@ -1860,7 +1860,7 @@ async function boot(){
  try{let d=await (await fetch('/api/readers')).json();readers=Array.isArray(d)?d:(d.readers||[]);}catch(e){readers=[];}
  readers=readers.filter(r=>r.id);
  if(!readers.length){main.innerHTML='<div class=card><div class=empty>'+t('noReaders')+'</div></div>';sel.innerHTML='<option>—</option>';return;}
- sel.innerHTML=readers.map(r=>`<option value="${r.id}">${esc(r.type||'reader')} · ${r.id}</option>`).join('');
+ sel.innerHTML=readers.map(r=>`<option value="${r.id}">${esc(r.name||r.type||'reader')} · ${r.id}</option>`).join('');
  let saved=localStorage.getItem('obihist');
  cur=readers.some(r=>r.id===saved)?saved:readers[0].id;
  sel.value=cur;

--- a/open_obi_energy_meter/src/main.cpp
+++ b/open_obi_energy_meter/src/main.cpp
@@ -297,6 +297,7 @@ bool gw_set_reader_name(const uint8_t handle[3], const char *name) {
     if (r.used && !memcmp(r.handle, handle, 3)) {
       saveName(handle, buf);
       strlcpy(r.name, buf, sizeof r.name);
+      r.mqttDiscovered = false;   // re-announce HA discovery so the device shows the new name
       return true;
     }
   return false;

--- a/open_obi_energy_meter/src/main.cpp
+++ b/open_obi_energy_meter/src/main.cpp
@@ -119,6 +119,21 @@ static uint16_t loadInterval(const uint8_t h[3]) {
   return v;
 }
 
+// Per-reader friendly name, persisted like the interval so it survives reboot AND re-pair.
+static void saveName(const uint8_t h[3], const char *name) {
+  char k[8]; uuidKey(h, k);
+  Preferences p; p.begin("obiname", false);
+  if (name && name[0]) p.putString(k, name); else p.remove(k);
+  p.end();
+}
+static void loadName(const uint8_t h[3], char *out, size_t outsz) {
+  char k[8]; uuidKey(h, k);
+  Preferences p; p.begin("obiname", true);
+  out[0] = 0;
+  p.getString(k, out, outsz);
+  p.end();
+}
+
 // Auto-pair window: while active, every reader that announces is accepted automatically.
 static uint32_t g_pairUntil = 0;
 static bool pairWindowActive() { return g_pairUntil && (int32_t)(millis() - g_pairUntil) < 0; }
@@ -133,6 +148,7 @@ static Reader *addReader(const uint8_t h[3]) {
     x.assigned = loadAssigned(h);                   // restore the accept flag (auto-binds on sight)
     uint16_t iv = loadInterval(h);                  // persisted upload interval (0 = never configured)
     x.setInterval = iv ? iv : OBI_DEFAULT_INTERVAL; // new/unconfigured reader -> default, so it's shown in UI/MQTT AND pushed in the ACK
+    loadName(h, x.name, sizeof x.name);             // restore the friendly name (empty = none set)
     return &x;
   }
   return nullptr;
@@ -260,6 +276,25 @@ bool gw_assign_reader(const uint8_t handle[3], bool on) {
       return true;
     }
   return true;   // persisted even if the reader isn't currently in the live list
+}
+// Set (or clear, with "") a reader's user-visible friendly name. Bounded copy; a 24-byte cut can land
+// inside a UTF-8 sequence, so trailing incomplete sequences are dropped. Control chars would break the
+// hand-built JSON (jstr only escapes quote/backslash), so they become spaces.
+void gw_set_reader_name(const uint8_t handle[3], const char *name) {
+  char buf[25];
+  strlcpy(buf, name ? name : "", sizeof buf);
+  for (char *c = buf; *c; c++) if ((uint8_t)*c < 0x20) *c = ' ';
+  size_t n = strlen(buf), i = n;
+  while (i && ((uint8_t)buf[i - 1] & 0xC0) == 0x80) i--;    // back over continuation bytes
+  if (i && (uint8_t)buf[i - 1] >= 0xC0) {                   // lead byte: sequence complete?
+    uint8_t lead = (uint8_t)buf[i - 1];
+    size_t need = lead >= 0xF0 ? 4 : lead >= 0xE0 ? 3 : 2;
+    if (n - (i - 1) < need) n = i - 1;                      // incomplete -> drop the whole sequence
+  }
+  buf[n] = 0;
+  saveName(handle, buf);
+  for (auto &r : readers)
+    if (r.used && !memcmp(r.handle, handle, 3)) { strlcpy(r.name, buf, sizeof r.name); return; }
 }
 // Open a window during which every announcing reader is auto-accepted (default 3 min from the web button).
 void gw_pair_all(uint16_t seconds) {

--- a/open_obi_energy_meter/src/main.cpp
+++ b/open_obi_energy_meter/src/main.cpp
@@ -44,7 +44,7 @@ const uint8_t GWID[6] = { 'O', 'B', 'I', 'E', 'S', 'P' };
 SX1262 radio = new Module(PIN_LORA_NSS, PIN_LORA_DIO1, PIN_LORA_RST, PIN_LORA_BUSY);
 
 // ---- per-reader state (struct in reader.h, shared with the web/MQTT module) --
-const int MAX_READERS = 64;   // ~92 B/entry -> ~6 KB RAM for 64; the real ceiling is LoRa airtime, not memory
+const int MAX_READERS = 64;   // ~117 B/entry -> ~7.5 KB RAM for 64; the real ceiling is LoRa airtime, not memory
 Reader readers[MAX_READERS];
 
 // Default upload interval (seconds) for a NEW reader that the user hasn't configured yet. A fresh reader is
@@ -280,7 +280,8 @@ bool gw_assign_reader(const uint8_t handle[3], bool on) {
 // Set (or clear, with "") a reader's user-visible friendly name. Bounded copy; a 24-byte cut can land
 // inside a UTF-8 sequence, so trailing incomplete sequences are dropped. Control chars would break the
 // hand-built JSON (jstr only escapes quote/backslash), so they become spaces.
-void gw_set_reader_name(const uint8_t handle[3], const char *name) {
+// Only accepted for a known (live) reader; the HTTP layer turns a false return into a 400.
+bool gw_set_reader_name(const uint8_t handle[3], const char *name) {
   char buf[25];
   strlcpy(buf, name ? name : "", sizeof buf);
   for (char *c = buf; *c; c++) if ((uint8_t)*c < 0x20) *c = ' ';
@@ -292,9 +293,13 @@ void gw_set_reader_name(const uint8_t handle[3], const char *name) {
     if (n - (i - 1) < need) n = i - 1;                      // incomplete -> drop the whole sequence
   }
   buf[n] = 0;
-  saveName(handle, buf);
   for (auto &r : readers)
-    if (r.used && !memcmp(r.handle, handle, 3)) { strlcpy(r.name, buf, sizeof r.name); return; }
+    if (r.used && !memcmp(r.handle, handle, 3)) {
+      saveName(handle, buf);
+      strlcpy(r.name, buf, sizeof r.name);
+      return true;
+    }
+  return false;
 }
 // Open a window during which every announcing reader is auto-accepted (default 3 min from the web button).
 void gw_pair_all(uint16_t seconds) {


### PR DESCRIPTION
My additional trackers are arriving soon, and since I have the memory of a goldfish, speaking names (friendly names) are important to me — I want to see "Allgemeinstrom", "Heizung" or "Wohnung" instead of a 3-byte hex handle.

This PR adds a user-assigned **friendly name per reader** to the open gateway firmware:

- **✎ Rename button** on each dashboard card opens an inline input (Enter/✓ saves, Esc/✕ cancels) — the name shows as the card title, the hex id moves into the small meta line. Without a name everything looks exactly as before.
- **History page** reader dropdown shows `Heizung · e1c6c5` instead of `meter · e1c6c5`.
- **Home Assistant** shows the name as the **device name** (Tasmota-style): the discovery config is re-published on rename. `unique_id`s and state topics are untouched, so existing entity ids, dashboards and long-term history are safe; without a name the device keeps its `OBI meter <id>` default.
- **Persisted in NVS** (namespace `obiname`, keyed by handle — same pattern as the existing interval/assignment stores). Empty name clears the entry.
- **New endpoint** `POST /api/name?id=<handle>&name=<text>` (behind the login guard, 400 for unknown readers); `/api/readers` gains a `name` field.
- **DE/EN** strings included.

MQTT state JSON/topics, the e-paper output and the LoRa protocol are untouched.

Details: names are limited to 24 bytes UTF-8 (truncated at a character boundary server-side), HTML-escaped client-side and JSON-escaped server-side, control characters are filtered.

Verified on my OBI C3 gateway (flashed via self-OTA)
