### PR TITLE
Fix ntp not being setup on normal wifi connect

### DIFF
--- a/open_obi_energy_meter/src/gateway_web.cpp
+++ b/open_obi_energy_meter/src/gateway_web.cpp
@@ -2174,6 +2174,7 @@ static void startServices() {
   mqtt.setCallback(mqttCallback);          // <base>/<id>/set_interval command topic
   bool sta = WiFi.status() == WL_CONNECTED;
   g_serverUp = true; g_wifiOk = sta;
+  if (sta) syncNtp();
   Serial.printf("[web] dashboard up: http://%s/  (%s)\n",
                 (sta ? WiFi.localIP() : WiFi.softAPIP()).toString().c_str(),
                 sta ? "connected" : "setup AP — use the WiFi button to configure");


### PR DESCRIPTION
NTP setup is currently only performed on wifi reconnect or NTP settings change. This means in a startup with saved settings that is already connected in startServices it was never executed leaving the device without current time. This PR fixes that by explicitly calling it from startServices in that case. For me time is now reliably available after a flash/restart.