### PR TITLE
Add a note about escaped line breaks when using the BLE console

### DIFF
--- a/04-connect-your-own-cloud/README.md
+++ b/04-connect-your-own-cloud/README.md
@@ -99,8 +99,10 @@ flowchart TD
        --pair-sensor --ssid <your-wifi> --password <your-wifi-pw>
    ```
    (Or use the web tool [../06-tools/obi_gateway_ble.html](../06-tools/obi_gateway_ble.html) and paste the
-   `SetTMPCertificate` fields from `ble_config.json`. On Linux, Web Bluetooth is behind a flag there —
-   enable `chrome://flags/#enable-experimental-web-platform-features` and relaunch the browser first.)
+   `SetTMPCertificate` fields from `ble_config.json`. Note that you must unescape or replace the escaped 
+   line breaks (`\n`) in the JSON to use the values. 
+   On Linux, Web Bluetooth is behind a flag there —  enable 
+   `chrome://flags/#enable-experimental-web-platform-features` and relaunch the browser first.)
 
    > ⚠️ **Stock firmware 1.0.1 caveat:** the WiFi password is only handled correctly up to **32 bytes** on
    > the device side — a longer one is silently truncated/rejected and the bridge fails to join. Keep it

--- a/de/04-eigene-cloud.md
+++ b/de/04-eigene-cloud.md
@@ -94,9 +94,11 @@ flowchart TD
        --ssid <dein-wlan> --password <dein-wlan-pw>
    ```
    (Oder das Web‑Tool [../06-tools/obi_gateway_ble.html](../06-tools/obi_gateway_ble.html) und die
-   `SetTMPCertificate`‑Felder aus `ble_config.json` einfügen. Unter Linux steckt Web Bluetooth dort hinter
-   einem Flag — vorher `chrome://flags/#enable-experimental-web-platform-features` aktivieren und den
-   Browser neu starten.)
+   `SetTMPCertificate`‑Felder aus `ble_config.json` einfügen.
+   Hierbei ist es wichtig, die im JSON escapten Zeilenumbrüche (`\n`) durch normale Zeilenumbrüche zu 
+   ersetzen bzw. zu unescapen, um die Werte verwenden zu können.
+   Unter Linux steckt Web Bluetooth dort hinter einem Flag — vorher 
+   `chrome://flags/#enable-experimental-web-platform-features` aktivieren und den Browser neu starten.)
 
    > ⚠️ **Stolperstein Stock‑Firmware 1.0.1:** Das WLAN‑Passwort wird geräteseitig nur bis **32 Byte**
    > korrekt verarbeitet — ein längeres wird stillschweigend abgeschnitten bzw. abgelehnt, und die Bridge


### PR DESCRIPTION
Simply pasting the values from the JSON will cause TLS issues when connecting to MQTT. It's necessary to unescape the line-breaks in the certificates. 