### PR TITLE
Add small bluetooth scanner script

### DIFF
--- a/04-connect-your-own-cloud/README.md
+++ b/04-connect-your-own-cloud/README.md
@@ -13,8 +13,16 @@ device). There are two ways to get it — the cloud way is the easiest and needs
 
 ### Way 1 — from the cloud (easiest — just needs an OBI login + the BLE name)
 
-You only need **three things**: an OBI account email, its password, and the device's **BLE name** — the
-`OBI-XXXXXX` it advertises (read it with any BLE scanner — it is *not* printed on the device). That name *is* the challenge id.
+You only need **three things**: an OBI account email, its password, and the device's **BLE name**.
+
+After plugging in the new device or pressing the button on the Bride for two seconds the Bluetooth name `OBI-XXXXXX` can be determined with any Scanner or the following script:
+```bash
+python tools/ble_scan.py
+# Scanning for Bluetooth devices for 5 seconds:
+# 34:B7:01:02:03:04: OBI-XXXXXX
+# Found 1 OBI device(s)
+```
+
 The device does **not** have to be registered to your account — any valid OBI login works and the endpoint
 returns the key for whatever `OBI-XXXXXX` you ask for (see [security notes](../03-reverse-engineering/security-notes.md)).
 

--- a/04-connect-your-own-cloud/tools/README.md
+++ b/04-connect-your-own-cloud/tools/README.md
@@ -4,6 +4,7 @@ Self-hosting toolkit. Generates your **own** PKI at runtime — no secrets are s
 
 | Tool | Role |
 |---|---|
+| `ble_scan.py` | Scans for BLE devices whose name starts with `OBI-` |
 | `fetch_tea_key.py` | Get the device TEA key from the cloud: **email + password + BLE name → key** (stdlib only) |
 | `gen_certs.py` | One-shot PKI: CA, server cert, claim cert, permanent ("consistent") cert + `ble_config.json` |
 | `mqtts_server.py` | Minimal MQTTS broker (TLS 8883): emulates AWS-IoT fleet provisioning, logs everything, and can push downlinks — `--set-interval N` (reader upload rate) and `--ota-firmware fw.bin` (flash an image) |

--- a/04-connect-your-own-cloud/tools/ble_scan.py
+++ b/04-connect-your-own-cloud/tools/ble_scan.py
@@ -1,0 +1,24 @@
+"""Discover nearby OBI Bluetooth Low Energy devices."""
+import asyncio
+from bleak import BleakScanner
+
+async def scan() -> int:
+    """Scan for five seconds and list devices whose name starts with ``OBI-``."""
+    timeout_seconds = 5
+    print(f"Scanning for Bluetooth devices for {timeout_seconds} seconds:")
+
+    devices = await BleakScanner.discover(timeout=timeout_seconds)
+    obi_devices = [device for device in devices if device.name and device.name.startswith("OBI-")]
+
+    for device in obi_devices:
+        print(device)
+
+    if not obi_devices:
+        print("No OBI devices found")
+    else:
+        print(f"Found {len(obi_devices)} OBI device(s)")
+
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(scan()))

--- a/ANLEITUNG.md
+++ b/ANLEITUNG.md
@@ -16,10 +16,16 @@ Schritt für Schritt abarbeiten. Alle Keys/Zertifikate hier sind Platzhalter —
   ```
   Diesen MQTT-broker benutzt Du auf Deinem Rechner während der Einrichtung, um vom der Bridge zu lesen / darauf zu schreiben.
 - Bluetooth am Rechner (für den BLE‑Push) **oder** ein Handy/Browser mit Web‑Bluetooth.
-- Den **BLE‑Namen** des Geräts: `OBI-XXXXXX` (mit einem beliebigen BLE‑Scanner auslesen — er steht *nicht* auf dem Gerät).
 - Ein heyObi-Konto **oder** ein UART interface an Deinem Rechner
 
 ---
+
+## Schritt 0 — BLE Namen ermitteln
+Nach einstecken des uneingerichteten Geräts oder Drücken der Taste an der Bridge kann der Bluetooth Name `OBI-XXXXXX` mit einem Scanner oder dem folgenden Script ermittelt werden:
+```bash
+cd 04-connect-your-own-cloud/tools
+python ble_scan.py
+```
 
 ## Schritt 1 — TEA‑Key des Geräts holen
 Der Key verschlüsselt den BLE‑Steuerkanal. **Ein** Weg reicht:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -10,7 +10,13 @@ placeholders — you generate your own. 🇩🇪 **Deutsche Version: [ANLEITUNG.
 - A **machine on the same LAN** (your broker host), port **8883** open.
 - **Python 3** + once: `pip install cryptography bleak paho-mqtt`.
 - Bluetooth on that machine (BLE push) **or** a Web‑Bluetooth browser.
-- The device **BLE name** `OBI-XXXXXX` (read it with any BLE scanner — it is *not* printed on the device).
+
+## Step 0 — get the BLE name
+After plugging in the new device or pressing the button on the Bride for two seconds the Bluetooth name `OBI-XXXXXX` can be determined with any Scanner or the following script:
+```bash
+cd 04-connect-your-own-cloud/tools
+python ble_scan.py
+```
 
 ## Step 1 — get the TEA key (one way is enough)
 ```bash


### PR DESCRIPTION
Helps users find their OBI device name without needing a separate scanner.